### PR TITLE
Fix import

### DIFF
--- a/llms/azure/__init__.py
+++ b/llms/azure/__init__.py
@@ -1,6 +1,6 @@
 # azure/__init__.py
 from .gpt35turbo import AzureGPT35Turbo as azure_gpt_35_turbo
-from .gpt35turbo16k import AzureGPT35Turbo16k as azure_gpt35_turbo_16k
+from .gpt35turbo16k import AzureGPT35Turbo16k as azure_gpt_35_turbo_16k
 from .gpt4turbo import AzureGPT4Turbo as azure_gpt_4_turbo
 from .gpt4o import AzureGPT4o as azure_gpt_4o
 from .gpt4 import AzureGPT4 as azure_gpt_4


### PR DESCRIPTION
This should fix this problem:
```
>>> from llms.azure import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'llms.azure' has no attribute 'azure_gpt_35_turbo_16k'. Did you mean: 'azure_gpt35_turbo_16k'?
```